### PR TITLE
added Issuer to Okta settings in appsettings.json

### DIFF
--- a/OktaAspNetCoreMvc/appsettings.json
+++ b/OktaAspNetCoreMvc/appsettings.json
@@ -6,7 +6,8 @@
     }
   },
   "Okta": {
-    "Authority": "https://{yourOktaDomain}.com/oauth2/default",
+    /* "Authority": "https://{yourOktaDomain}.com/oauth2/default", */ 
+    "Issuer": "https://{yourOktaDomain}.com/oauth2/default",
     "ClientId": "{clientId}",
     "ClientSecret": "{clientSecret}"
   }


### PR DESCRIPTION
When running this locally I received a runtime error during validation of OpenID Connect settings, and resolved the problem by replacing "Authority" with "Issuer" in the Okta settings in appsettings.json.